### PR TITLE
Run Docker container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+RUN useradd --create-home appuser
+USER appuser
+
 EXPOSE 8080
 
 CMD ["python", "kanjo-web.py"]


### PR DESCRIPTION
## Summary
- Add `useradd --create-home appuser` and `USER appuser` to Dockerfile
- Container now runs as non-root user, reducing blast radius if compromised

## Test plan
- [ ] `docker build` succeeds
- [ ] `docker run` starts the app correctly
- [ ] Verify process runs as `appuser` inside container

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)